### PR TITLE
Add URLs to incident pages 

### DIFF
--- a/CODE/generate_DISARM_pages.py
+++ b/CODE/generate_DISARM_pages.py
@@ -158,6 +158,8 @@ class Disarm:
                                                                   'resources_needed', 'resource', ',')
         self.cross_detectionid_actortypeid = self.create_cross_table(self.df_detections[['disarm_id', 'actortypes']], 
                                                                   'actortypes', 'actortype', ',')
+        self.cross_incidentid_urls = self.create_cross_table(self.df_incidents[['disarm_id', 'urls']], 
+                                                                  'urls', 'url', ' ')        
 
 
     def create_incident_technique_crosstable(self, it_metadata):
@@ -212,14 +214,14 @@ class Disarm:
     def create_incident_urls_string(self, incidentid):
     
         urlsstr = '''
-|                    Reference                            |
+| Reference(s) |
+| --------- |
 '''
 
-        urlsrow = '| [{0}]({0})|\n'
-        incident = self.df_incidents[self.df_incidents['disarm_id']==incidentid]
-        urls_series = incident['urls'].series.str.split(' ',expand=True).explode
-        for u in urls_series:
-            urlsstr += urlsrow.format(u)
+        urlsrow = '| [{0}]({0}) |\n'      
+        incidentid_urls = self.cross_incidentid_urls[self.cross_incidentid_urls['disarm_id']==incidentid]
+        for index, row in incidentid_urls.iterrows():
+            urlsstr += urlsrow.format(row['url_id'])  
         return urlsstr
         
         
@@ -506,7 +508,7 @@ class Disarm:
                                                tocountry=row['found_in_country'],
                                                foundvia=row['found_via'],
                                                dateadded=row['when_added'],
-                                               urls=self.create_incident_urls_string(row['disarm_id'])),
+                                               urls=self.create_incident_urls_string(row['disarm_id']),
                                                techniques=self.create_incident_techniques_string(row['disarm_id']))
                 if objecttype == 'actortype':
                     metatext = template.format(type = 'Actor', id=row['disarm_id'], name=row['name'], 

--- a/CODE/generate_DISARM_pages.py
+++ b/CODE/generate_DISARM_pages.py
@@ -209,6 +209,20 @@ class Disarm:
         return incidentstr
 
 
+    def create_incident_urls_string(self, incidentid):
+    
+        urlsstr = '''
+|                    Reference                            |
+'''
+
+        urlsrow = '| [{0}]({0})|\n'
+        incident = self.df_incidents[self.df_incidents['disarm_id']==incidentid]
+        urls_series = incident['urls'].series.str.split(' ',expand=True).explode
+        for u in urls_series:
+            urlsstr += urlsrow.format(u)
+        return urlsstr
+        
+        
     def create_incident_techniques_string(self, incidentid):
 
         techstr = '''
@@ -492,6 +506,7 @@ class Disarm:
                                                tocountry=row['found_in_country'],
                                                foundvia=row['found_via'],
                                                dateadded=row['when_added'],
+                                               urls=self.create_incident_urls_string(row['disarm_id'])),
                                                techniques=self.create_incident_techniques_string(row['disarm_id']))
                 if objecttype == 'actortype':
                     metatext = template.format(type = 'Actor', id=row['disarm_id'], name=row['name'], 

--- a/CODE/page_templates/template_incident.md
+++ b/CODE/page_templates/template_incident.md
@@ -11,6 +11,8 @@
 * **Found via:** {foundvia}
 
 * **Date added:** {dateadded}
+
+{urls}
  
 {techniques}
 

--- a/generated_pages/incidents/I00001.md
+++ b/generated_pages/incidents/I00001.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://money.cnn.com/2017/09/28/media/blacktivist-russia-facebook-twitter/index.html](https://money.cnn.com/2017/09/28/media/blacktivist-russia-facebook-twitter/index.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00002.md
+++ b/generated_pages/incidents/I00002.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.washingtonpost.com/science/2018/08/23/russian-trolls-twitter-bots-exploit-vaccine-controversy/](https://www.washingtonpost.com/science/2018/08/23/russian-trolls-twitter-bots-exploit-vaccine-controversy/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00003.md
+++ b/generated_pages/incidents/I00003.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.theguardian.com/us-news/2018/may/10/russia-facebook-ads-us-elections-congress](https://www.theguardian.com/us-news/2018/may/10/russia-facebook-ads-us-elections-congress) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00004.md
+++ b/generated_pages/incidents/I00004.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [http://www.niemanlab.org/2018/09/how-france-beat-back-information-manipulation-and-how-other-democracies-might-do-the-same/](http://www.niemanlab.org/2018/09/how-france-beat-back-information-manipulation-and-how-other-democracies-might-do-the-same/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00005.md
+++ b/generated_pages/incidents/I00005.md
@@ -20,6 +20,12 @@ The report adds that although officially the Russian government asserted its neu
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.forbes.com/sites/emmawoollacott/2018/11/01/russian-trolls-used-islamophobia-to-whip-up-support-for-brexit/#1369afb665f2](https://www.forbes.com/sites/emmawoollacott/2018/11/01/russian-trolls-used-islamophobia-to-whip-up-support-for-brexit/#1369afb665f2) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00006.md
+++ b/generated_pages/incidents/I00006.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://en.wikipedia.org/wiki/Columbian_Chemicals_Plant_explosion_hoax](https://en.wikipedia.org/wiki/Columbian_Chemicals_Plant_explosion_hoax) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00007.md
+++ b/generated_pages/incidents/I00007.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.politifact.com/truth-o-meter/statements/2016/aug/16/paul-manafort/trump-campaign-chair-misquotes-russian-media-makes/](https://www.politifact.com/truth-o-meter/statements/2016/aug/16/paul-manafort/trump-campaign-chair-misquotes-russian-media-makes/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00008.md
+++ b/generated_pages/incidents/I00008.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.stopfake.org/en/vencislav-the-virgin-hostile-operation-by-vencislav-bujic-seas-foundation-and-its-network-of-collaborators/](https://www.stopfake.org/en/vencislav-the-virgin-hostile-operation-by-vencislav-bujic-seas-foundation-and-its-network-of-collaborators/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00009.md
+++ b/generated_pages/incidents/I00009.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://codastory.com/disinformation/how-a-little-known-pro-kremlin-analyst-became-a-philippine-expert-overnight/](https://codastory.com/disinformation/how-a-little-known-pro-kremlin-analyst-became-a-philippine-expert-overnight/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00010.md
+++ b/generated_pages/incidents/I00010.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-01
+
+
+| Reference(s) |
+| --------- |
+| [https://www.nytimes.com/2018/03/27/us/parkland-students-hogg-gonzalez.html](https://www.nytimes.com/2018/03/27/us/parkland-students-hogg-gonzalez.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00011.md
+++ b/generated_pages/incidents/I00011.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-01
+
+
+| Reference(s) |
+| --------- |
+| [https://www.wcpo.com/news/national/fact-check-viral-misinformation-about-covington-catholic-nathan-phillips-infects-the-internet](https://www.wcpo.com/news/national/fact-check-viral-misinformation-about-covington-catholic-nathan-phillips-infects-the-internet) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00012.md
+++ b/generated_pages/incidents/I00012.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.cjr.org/innovations/memes-pollution-censorship-china-beijing.php](https://www.cjr.org/innovations/memes-pollution-censorship-china-beijing.php) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00013.md
+++ b/generated_pages/incidents/I00013.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://medium.com/dfrlab/trolltracker-glimpse-into-a-french-operation-f78dcae78924](https://medium.com/dfrlab/trolltracker-glimpse-into-a-french-operation-f78dcae78924) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00014.md
+++ b/generated_pages/incidents/I00014.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.wired.com/story/co-opting-french-unrest-spread-disinformation/](https://www.wired.com/story/co-opting-french-unrest-spread-disinformation/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00015.md
+++ b/generated_pages/incidents/I00015.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-01
+
+
+| Reference(s) |
+| --------- |
+| [https://www.theatlantic.com/politics/archive/2019/02/new-mueller-filing-shows-how-russia-misuses-us-courts/581884/](https://www.theatlantic.com/politics/archive/2019/02/new-mueller-filing-shows-how-russia-misuses-us-courts/581884/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00016.md
+++ b/generated_pages/incidents/I00016.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-02-01
+
+
+| Reference(s) |
+| --------- |
+| [https://www.ft.com/content/b3701b12-2544-11e9-b329-c7e6ceb5ffdf](https://www.ft.com/content/b3701b12-2544-11e9-b329-c7e6ceb5ffdf) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00017.md
+++ b/generated_pages/incidents/I00017.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.dni.gov/files/documents/ICA_2017_01.pdf](https://www.dni.gov/files/documents/ICA_2017_01.pdf) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00018.md
+++ b/generated_pages/incidents/I00018.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| []() |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00019.md
+++ b/generated_pages/incidents/I00019.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.buzzfeednews.com/article/ryanhatesthis/heres-how-far-right-trolls-are-spreading-hoaxes-about](https://www.buzzfeednews.com/article/ryanhatesthis/heres-how-far-right-trolls-are-spreading-hoaxes-about) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00020.md
+++ b/generated_pages/incidents/I00020.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://medium.com/@DFRLab/three-thousand-fake-tanks-575410c4f64d](https://medium.com/@DFRLab/three-thousand-fake-tanks-575410c4f64d) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00021.md
+++ b/generated_pages/incidents/I00021.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://medium.com/dfrlab/fakes-bots-and-blockings-in-armenia-44a4c87ebc46](https://medium.com/dfrlab/fakes-bots-and-blockings-in-armenia-44a4c87ebc46) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00022.md
+++ b/generated_pages/incidents/I00022.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://medium.com/dfrlab/hashtag-campaign-macronleaks-4a3fb870c4e8](https://medium.com/dfrlab/hashtag-campaign-macronleaks-4a3fb870c4e8) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00023.md
+++ b/generated_pages/incidents/I00023.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://medium.com/dfrlab/russian-and-french-twitter-mobs-in-election-push-bca327aa41a5](https://medium.com/dfrlab/russian-and-french-twitter-mobs-in-election-push-bca327aa41a5) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00024.md
+++ b/generated_pages/incidents/I00024.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://medium.com/dfrlab/how-the-alt-right-brought-syriahoax-to-america-47745118d1c9](https://medium.com/dfrlab/how-the-alt-right-brought-syriahoax-to-america-47745118d1c9) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00025.md
+++ b/generated_pages/incidents/I00025.md
@@ -13,6 +13,12 @@ Verdict: “An EU army marching out to war under Brussels’ command is a fantas
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://medium.com/dfrlab/spread-it-on-reddit-3170a463e787](https://medium.com/dfrlab/spread-it-on-reddit-3170a463e787) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00026.md
+++ b/generated_pages/incidents/I00026.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.washingtonpost.com/opinions/russias-influence-in-western-elections/2016/04/08/b427602a-fcf1-11e5-886f-a037dba38301_story.html](https://www.washingtonpost.com/opinions/russias-influence-in-western-elections/2016/04/08/b427602a-fcf1-11e5-886f-a037dba38301_story.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00027.md
+++ b/generated_pages/incidents/I00027.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://helda.helsinki.fi//bitstream/handle/10138/233374/KhaldarovaPanttiFakeNews.pdf?sequence=1](https://helda.helsinki.fi//bitstream/handle/10138/233374/KhaldarovaPanttiFakeNews.pdf?sequence=1) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00028.md
+++ b/generated_pages/incidents/I00028.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.stopfake.org/en/lies-spanish-flight-operations-officer-from-kiev-informed-about-ukrainian-planes-involved-in-boeing-tragedy/%20https:/globalvoices.org/2014/07/20/the-russian-governments-7000-wikipedia-edits/%20https:/foreignpolicy.com/2016/09/29/how-mh17-gave-birth-to-the-modern-russian-spin-machine-putin-ukraine/](https://www.stopfake.org/en/lies-spanish-flight-operations-officer-from-kiev-informed-about-ukrainian-planes-involved-in-boeing-tragedy/%20https:/globalvoices.org/2014/07/20/the-russian-governments-7000-wikipedia-edits/%20https:/foreignpolicy.com/2016/09/29/how-mh17-gave-birth-to-the-modern-russian-spin-machine-putin-ukraine/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00029.md
+++ b/generated_pages/incidents/I00029.md
@@ -11,6 +11,14 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.novayagazeta.ru/news/2015/05/07/112052-facebook-zablokiroval-sergeya-parhomenko-za-kommentariy-doklada-o-sbitom-171-boinge-187%20](https://www.novayagazeta.ru/news/2015/05/07/112052-facebook-zablokiroval-sergeya-parhomenko-za-kommentariy-doklada-o-sbitom-171-boinge-187%20) |
+| [https://news.online.ua/754036/v-sotssetyah-na-paltsah-pokazali-kak-rabotayut-boty-kremlya-opublikovany-foto/](https://news.online.ua/754036/v-sotssetyah-na-paltsah-pokazali-kak-rabotayut-boty-kremlya-opublikovany-foto/) |
+| [https://www.mirror.co.uk/news/world-news/ukraine-involved-mh17-downing-claims-14184413](https://www.mirror.co.uk/news/world-news/ukraine-involved-mh17-downing-claims-14184413) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00030.md
+++ b/generated_pages/incidents/I00030.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://slate.com/culture/2018/10/last-jedi-star-wars-twitter-backlash-russia-trolls.html](https://slate.com/culture/2018/10/last-jedi-star-wars-twitter-backlash-russia-trolls.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00031.md
+++ b/generated_pages/incidents/I00031.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://ajph.aphapublications.org/doi/pdf/10.2105/AJPH.2018.304567](https://ajph.aphapublications.org/doi/pdf/10.2105/AJPH.2018.304567) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00032.md
+++ b/generated_pages/incidents/I00032.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://qz.com/1409102/russian-trolls-and-bots-are-flooding-twitter-with-ford-kavanaugh-disinformation/](https://qz.com/1409102/russian-trolls-and-bots-are-flooding-twitter-with-ford-kavanaugh-disinformation/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00033.md
+++ b/generated_pages/incidents/I00033.md
@@ -11,6 +11,13 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://gking.harvard.edu/files/gking/files/how_the_chinese_government_fabricates_social_media_posts_for_strategic_distraction_not_engaged_argument.pdf](https://gking.harvard.edu/files/gking/files/how_the_chinese_government_fabricates_social_media_posts_for_strategic_distraction_not_engaged_argument.pdf) |
+| [https://www.voanews.com/a/who-is-that-chinese-troll/3540663.html](https://www.voanews.com/a/who-is-that-chinese-troll/3540663.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00034.md
+++ b/generated_pages/incidents/I00034.md
@@ -13,6 +13,13 @@ Unique for taking place outside of the Chinese Internet system, both transgressi
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.ideals.illinois.edu/handle/2142/96746](https://www.ideals.illinois.edu/handle/2142/96746) |
+| [https://qz.com/598812/an-army-of-chinese-trolls-has-jumped-the-great-firewall-to-attack-taiwanese-independence-on-facebook/](https://qz.com/598812/an-army-of-chinese-trolls-has-jumped-the-great-firewall-to-attack-taiwanese-independence-on-facebook/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00035.md
+++ b/generated_pages/incidents/I00035.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://blogs.oii.ox.ac.uk/politicalbots/wp-content/uploads/sites/89/2017/06/Comprop-Brazil-1.pdf](https://blogs.oii.ox.ac.uk/politicalbots/wp-content/uploads/sites/89/2017/06/Comprop-Brazil-1.pdf) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00036.md
+++ b/generated_pages/incidents/I00036.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.wilsoncenter.org/blog-post/bots-brazil-the-activity-social-media-bots-brazilian-elections](https://www.wilsoncenter.org/blog-post/bots-brazil-the-activity-social-media-bots-brazilian-elections) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00037.md
+++ b/generated_pages/incidents/I00037.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www1.folha.uol.com.br/poder/eleicoes-2016/2016/10/1823713-eleicao-no-rio-tem-tatica-antiboato-e-suspeita-de-uso-de-robos.shtml](https://www1.folha.uol.com.br/poder/eleicoes-2016/2016/10/1823713-eleicao-no-rio-tem-tatica-antiboato-e-suspeita-de-uso-de-robos.shtml) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00038.md
+++ b/generated_pages/incidents/I00038.md
@@ -11,6 +11,13 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [http://www.labic.net/cartografia/a-rede-das-imagens-da-vaiadilma-novas-relacoes/](http://www.labic.net/cartografia/a-rede-das-imagens-da-vaiadilma-novas-relacoes/) |
+| [https://www.researchgate.net/publication/300415619_The_Influence_of_Retweeting_Robots_During_Brazilian_Protests](https://www.researchgate.net/publication/300415619_The_Influence_of_Retweeting_Robots_During_Brazilian_Protests) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00039.md
+++ b/generated_pages/incidents/I00039.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.buzzfeed.com/albertonardelli/hyperpartisan-sites-and-facebook-pages-are-publishing-false](https://www.buzzfeed.com/albertonardelli/hyperpartisan-sites-and-facebook-pages-are-publishing-false) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00040.md
+++ b/generated_pages/incidents/I00040.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://www.nytimes.com/2017/02/06/business/syria-refugee-anas-modamani-germany-facebook.html](https://www.nytimes.com/2017/02/06/business/syria-refugee-anas-modamani-germany-facebook.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00041.md
+++ b/generated_pages/incidents/I00041.md
@@ -11,6 +11,12 @@
 * **Found via:** OII
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://uebermedien.de/11488/kartenlegen-mit-kriminellen-auslaendern/](https://uebermedien.de/11488/kartenlegen-mit-kriminellen-auslaendern/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00042.md
+++ b/generated_pages/incidents/I00042.md
@@ -11,6 +11,12 @@
 * **Found via:** MIS
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://jia.sipa.columbia.edu/robot-wars-how-bots-joined-battle-gulf](https://jia.sipa.columbia.edu/robot-wars-how-bots-joined-battle-gulf) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00043.md
+++ b/generated_pages/incidents/I00043.md
@@ -11,6 +11,12 @@
 * **Found via:** MIS
 
 * **Date added:** 2019-02-24
+
+
+| Reference(s) |
+| --------- |
+| [https://gizmodo.com/how-an-investigation-of-fake-fcc-comments-snared-a-prom-1832788658](https://gizmodo.com/how-an-investigation-of-fake-fcc-comments-snared-a-prom-1832788658) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00044.md
+++ b/generated_pages/incidents/I00044.md
@@ -11,6 +11,12 @@
 * **Found via:** MIS
 
 * **Date added:** 2019-02-25
+
+
+| Reference(s) |
+| --------- |
+| [https://www.politifact.com/texas/article/2018/may/03/jade-helm-15-greg-abbott-texas-state-guard-hayden-/](https://www.politifact.com/texas/article/2018/may/03/jade-helm-15-greg-abbott-texas-state-guard-hayden-/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00045.md
+++ b/generated_pages/incidents/I00045.md
@@ -11,6 +11,13 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.bellingcat.com/tag/skripal/](https://www.bellingcat.com/tag/skripal/) |
+| [https://euvsdisinfo.eu/conspiracy-mania-marks-one-year-anniversary-of-the-skripal-poisoning/](https://euvsdisinfo.eu/conspiracy-mania-marks-one-year-anniversary-of-the-skripal-poisoning/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00046.md
+++ b/generated_pages/incidents/I00046.md
@@ -11,6 +11,13 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.nytimes.com/2018/09/16/world/europe/macedonia-referendum-russia-nato.html](https://www.nytimes.com/2018/09/16/world/europe/macedonia-referendum-russia-nato.html) |
+| [https://www.polygraph.info/a/disinfo-analysis-macedonia-nato-russia/29770631.html](https://www.polygraph.info/a/disinfo-analysis-macedonia-nato-russia/29770631.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00047.md
+++ b/generated_pages/incidents/I00047.md
@@ -12,6 +12,12 @@ The Russian Federal Security Service (FSB), which is also responsible for border
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://euvsdisinfo.eu/wave-of-disinformation-from-the-azov-sea/](https://euvsdisinfo.eu/wave-of-disinformation-from-the-azov-sea/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00048.md
+++ b/generated_pages/incidents/I00048.md
@@ -11,6 +11,13 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://thesyriacampaign.org/wp-content/uploads/2017/12/KillingtheTruth.pdf](https://thesyriacampaign.org/wp-content/uploads/2017/12/KillingtheTruth.pdf) |
+| [https://www.theguardian.com/world/2017/dec/18/syria-white-helmets-conspiracy-theories](https://www.theguardian.com/world/2017/dec/18/syria-white-helmets-conspiracy-theories) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00049.md
+++ b/generated_pages/incidents/I00049.md
@@ -11,6 +11,14 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [http://www.publications.atlanticcouncil.org/breakingghouta/disinformation-2/](http://www.publications.atlanticcouncil.org/breakingghouta/disinformation-2/) |
+| [https://www.bellingcat.com/news/mena/2018/12/18/chemical-weapons-and-absurdity-the-disinformation-campaign-against-the-white-helmets/](https://www.bellingcat.com/news/mena/2018/12/18/chemical-weapons-and-absurdity-the-disinformation-campaign-against-the-white-helmets/) |
+| [https://www.nybooks.com/daily/2018/10/16/why-assad-and-russia-target-the-white-helmets/](https://www.nybooks.com/daily/2018/10/16/why-assad-and-russia-target-the-white-helmets/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00050.md
+++ b/generated_pages/incidents/I00050.md
@@ -14,6 +14,12 @@ Maduro has remained defiant in the face of domestic and international pressure, 
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://euvsdisinfo.eu/twitter-as-an-information-battlefield-venezuela-a-case-study/](https://euvsdisinfo.eu/twitter-as-an-information-battlefield-venezuela-a-case-study/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00051.md
+++ b/generated_pages/incidents/I00051.md
@@ -12,6 +12,13 @@ The FCO comments on the IfS were issued after a news report said the group had r
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://eaworldview.com/2019/01/counter-russia-disinformation-integrity-initiative/](https://eaworldview.com/2019/01/counter-russia-disinformation-integrity-initiative/) |
+| [https://www.stopfake.org/en/kremlin-watch-briefing-the-eu-has-to-start-taking-pro-kremlin-disinformation-seriously/](https://www.stopfake.org/en/kremlin-watch-briefing-the-eu-has-to-start-taking-pro-kremlin-disinformation-seriously/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00052.md
+++ b/generated_pages/incidents/I00052.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.recordedfuture.com/china-social-media-operations/](https://www.recordedfuture.com/china-social-media-operations/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00053.md
+++ b/generated_pages/incidents/I00053.md
@@ -12,6 +12,13 @@ Geopolitically complex issue combines US/China trade; Security concerns/issues r
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.theatlantic.com/international/archive/2019/03/czech-zeman-babis-huawei-xi-trump/584158/](https://www.theatlantic.com/international/archive/2019/03/czech-zeman-babis-huawei-xi-trump/584158/) |
+| [https://www.theglobeandmail.com/politics/article-chinas-envoy-says-white-supremacy-played-part-in-canadas-arrest-of/](https://www.theglobeandmail.com/politics/article-chinas-envoy-says-white-supremacy-played-part-in-canadas-arrest-of/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00054.md
+++ b/generated_pages/incidents/I00054.md
@@ -11,6 +11,13 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.ctvnews.ca/world/china-says-foreign-concerns-over-muslim-rights-unwarranted-1.4178042](https://www.ctvnews.ca/world/china-says-foreign-concerns-over-muslim-rights-unwarranted-1.4178042) |
+| [https://www.reuters.com/investigates/special-report/muslims-camps-china/](https://www.reuters.com/investigates/special-report/muslims-camps-china/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00055.md
+++ b/generated_pages/incidents/I00055.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.voanews.com/a/who-is-that-chinese-troll/3540663.html](https://www.voanews.com/a/who-is-that-chinese-troll/3540663.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00056.md
+++ b/generated_pages/incidents/I00056.md
@@ -12,6 +12,17 @@ While there is history to Iran’s information/influence operations, starting wi
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.fireeye.com/blog/threat-research/2018/08/suspected-iranian-influence-operation.html](https://www.fireeye.com/blog/threat-research/2018/08/suspected-iranian-influence-operation.html) |
+| [https://www.reuters.com/article/us-cyber-iran-specialreport/special-report-how-iran-spreads-disinformation-around-the-world-idUSKCN1NZ1FT](https://www.reuters.com/article/us-cyber-iran-specialreport/special-report-how-iran-spreads-disinformation-around-the-world-idUSKCN1NZ1FT) |
+| [https://www.reuters.com/article/us-cyber-iran-specialreport/special-report-how-iran-spreads-disinformation-around-the-world-idUSKCN1NZ1FT](https://www.reuters.com/article/us-cyber-iran-specialreport/special-report-how-iran-spreads-disinformation-around-the-world-idUSKCN1NZ1FT) |
+| [https://www.rand.org/blog/2018/08/irans-disinformation-campaigns.html](https://www.rand.org/blog/2018/08/irans-disinformation-campaigns.html) |
+| [https://medium.com/dfrlab/takedown-details-of-the-iranian-propaganda-network-d1fad32fdf30](https://medium.com/dfrlab/takedown-details-of-the-iranian-propaganda-network-d1fad32fdf30) |
+| [https://medium.com/dfrlab/trolltracker-outward-influence-operation-from-iran-cc4539684c8dhttps://comprop.oii.ox.ac.uk/wp-content/uploads/sites/93/2019/04/Iran-Memo.pdf](https://medium.com/dfrlab/trolltracker-outward-influence-operation-from-iran-cc4539684c8dhttps://comprop.oii.ox.ac.uk/wp-content/uploads/sites/93/2019/04/Iran-Memo.pdf) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00057.md
+++ b/generated_pages/incidents/I00057.md
@@ -11,6 +11,13 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.smh.com.au/world/north-america/misinformation-seeded-by-bots-and-trolls-invades-mexico-s-election-20180502-p4zctx.html](https://www.smh.com.au/world/north-america/misinformation-seeded-by-bots-and-trolls-invades-mexico-s-election-20180502-p4zctx.html) |
+| [https://medium.com/dfrlab/electionwatch-russian-bots-in-mexico-46003fcab4](https://medium.com/dfrlab/electionwatch-russian-bots-in-mexico-46003fcab4) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00058.md
+++ b/generated_pages/incidents/I00058.md
@@ -11,6 +11,13 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.thebureauinvestigates.com/stories/2018-09-04/chemnitz-far-right-alternative-news](https://www.thebureauinvestigates.com/stories/2018-09-04/chemnitz-far-right-alternative-news) |
+| [http://www.spiegel.de/international/germany/merkel-facing-turbulence-after-right-wing-unrest-a-1228121.html](http://www.spiegel.de/international/germany/merkel-facing-turbulence-after-right-wing-unrest-a-1228121.html) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00059.md
+++ b/generated_pages/incidents/I00059.md
@@ -11,6 +11,14 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.reuters.com/investigates/special-report/myanmar-facebook-hate/](https://www.reuters.com/investigates/special-report/myanmar-facebook-hate/) |
+| [https://www.nytimes.com/2018/10/15/technology/myanmar-facebook-genocide.html?action=click&module=Top%20Stories&pgtype=Homepage](https://www.nytimes.com/2018/10/15/technology/myanmar-facebook-genocide.html?action=click&module=Top%20Stories&pgtype=Homepage) |
+| [https://www.lawfareblog.com/facebooks-role-genocide-myanmar-new-reporting-complicates-narrative](https://www.lawfareblog.com/facebooks-role-genocide-myanmar-new-reporting-complicates-narrative) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00060.md
+++ b/generated_pages/incidents/I00060.md
@@ -11,6 +11,14 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.smh.com.au/world/oceania/the-high-price-of-white-genocide-politics-for-australia-20180724-p4zt9k.html](https://www.smh.com.au/world/oceania/the-high-price-of-white-genocide-politics-for-australia-20180724-p4zt9k.html) |
+| [https://www.theatlantic.com/politics/archive/2018/08/trump-white-nationalism/568393/](https://www.theatlantic.com/politics/archive/2018/08/trump-white-nationalism/568393/) |
+| [https://www.iafrikan.com/2018/11/20/social-media-usa-south-africa-fake-news-disinformation/](https://www.iafrikan.com/2018/11/20/social-media-usa-south-africa-fake-news-disinformation/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00061.md
+++ b/generated_pages/incidents/I00061.md
@@ -11,6 +11,15 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.stripes.com/congressmen-urge-fbi-to-investigate-bots-targeting-veterans-with-fake-news-1.573284](https://www.stripes.com/congressmen-urge-fbi-to-investigate-bots-targeting-veterans-with-fake-news-1.573284) |
+| [https://www.voanews.com/a/russia-influence-operations-taking-aim-at-us-military/4640751.html](https://www.voanews.com/a/russia-influence-operations-taking-aim-at-us-military/4640751.html) |
+| [https://www.washingtonpost.com/news/the-switch/wp/2017/10/09/russian-operatives-used-twitter-and-facebook-to-target-veterans-and-military-personnel-study-says/?utm_term=.d6fa34d4819c](https://www.washingtonpost.com/news/the-switch/wp/2017/10/09/russian-operatives-used-twitter-and-facebook-to-target-veterans-and-military-personnel-study-says/?utm_term=.d6fa34d4819c) |
+| [https://comprop.oii.ox.ac.uk/research/working-papers/vetops/](https://comprop.oii.ox.ac.uk/research/working-papers/vetops/) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00062.md
+++ b/generated_pages/incidents/I00062.md
@@ -11,6 +11,13 @@
 * **Found via:** 
 
 * **Date added:** 2019-03-20
+
+
+| Reference(s) |
+| --------- |
+| [https://www.politico.eu/article/britain-nationalist-dark-web-populism-tommy-robinson/?](https://www.politico.eu/article/britain-nationalist-dark-web-populism-tommy-robinson/?) |
+| [http://www.europarl.europa.eu/thinktank/en/document.html?reference=EPRS_STU(2019)634414](http://www.europarl.europa.eu/thinktank/en/document.html?reference=EPRS_STU(2019)634414) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00063.md
+++ b/generated_pages/incidents/I00063.md
@@ -13,6 +13,12 @@ The investigation found corroborating evidence after conducting witness intervie
 * **Found via:** 
 
 * **Date added:** 2019-04-06
+
+
+| Reference(s) |
+| --------- |
+| [https://www.nytimes.com/2016/05/13/sports/russia-doping-sochi-olympics-2014.html?module=inline](https://www.nytimes.com/2016/05/13/sports/russia-doping-sochi-olympics-2014.html?module=inline) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00064.md
+++ b/generated_pages/incidents/I00064.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2024-03-12
+
+
+| Reference(s) |
+| --------- |
+| [https://www.wired.co.uk/article/tinder-political-bots-jeremy-corbyn-labour](https://www.wired.co.uk/article/tinder-political-bots-jeremy-corbyn-labour) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00065.md
+++ b/generated_pages/incidents/I00065.md
@@ -11,6 +11,12 @@
 * **Found via:** 
 
 * **Date added:** 2024-03-12
+
+
+| Reference(s) |
+| --------- |
+| [https://www.mandiant.com/resources/blog/ghostwriter-influence-campaign](https://www.mandiant.com/resources/blog/ghostwriter-influence-campaign) |
+
  
 
 | Technique | Description given for this incident |

--- a/generated_pages/incidents/I00066.md
+++ b/generated_pages/incidents/I00066.md
@@ -20,6 +20,12 @@ This incident demonstrates how a hack of a mainstream news agency website allowe
 * **Found via:** 
 
 * **Date added:** 2024-03-12
+
+
+| Reference(s) |
+| --------- |
+| [https://www.bbc.co.uk/news/blogs-trending-44294826](https://www.bbc.co.uk/news/blogs-trending-44294826) |
+
  
 
 | Technique | Description given for this incident |


### PR DESCRIPTION
Amended the generate_DISARM_pages.py to list the URLs from the incidents sheet in DISARM_DATA_MASTER.xlsx. This involved amending the template for the incident mark down page, and creating and then looping through a cross table for each incident since there can be more than one URL in the 'urls' column (separated by a space).   